### PR TITLE
docker: add ability to build with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM debian:bookworm
+
+WORKDIR /tmp/workspace
+
+# enable contrib, non-free and non-free-firmware
+# required to find packages like rar
+RUN sed -i 's/Components: main/& contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources
+
+# enable installation of multiarch binaries
+# required to find packages like linux-headers-686:i386
+RUN dpkg --add-architecture i386
+
+# install packages required to build the image
+RUN apt update && apt -y install \
+	apt-transport-https \
+	build-essential \
+	colordiff \
+	git \
+	gnupg \
+	live-build \
+	make \
+	ovmf \
+	python3-apt \
+	python3-venv \
+	rename \
+	rsync \
+	sudo \
+	unzip \
+	wget
+
+# trust the temporary workspace directory
+RUN git config --global --add safe.directory /tmp/workspace
+
+# remove 'download_extra' to build without third party software/dotfiles
+CMD ["make", "doc", "download_extra", "build"]

--- a/Makefile
+++ b/Makefile
@@ -151,3 +151,10 @@ codespell:
 .PHONY: help # generate list of targets with descriptions
 help:
 	@grep '^.PHONY: .* #' Makefile | sed 's/\.PHONY: \(.*\) # \(.*\)/\1	\2/' | expand -t20
+
+#####
+
+.PHONY: docker_compose
+docker_compose:
+	docker compose up --build --force-recreate
+	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  debian-live-config:
+    build: .
+    privileged: true
+    volumes:
+      - .:/tmp/workspace


### PR DESCRIPTION
With docker we don't need to build from the same distribution as the target distribution.

Tested on Ubuntu 20.04.6 LTS