### PR TITLE
doc: fix broken link in docs,

### DIFF
--- a/doc/md/custom.md
+++ b/doc/md/custom.md
@@ -101,7 +101,7 @@ See [Makefile.extra](https://gitlab.com/nodiscc/debian-live-config/-/blob/master
 
 ### config/includes.installer/
 
-`preseed.cfg` is used to preconfigure the _installer_ using [preseeding](https://wiki.debian.org/Preseed).
+`preseed.cfg` is used to preconfigure the _installer_ using [preseeding](https://wiki.debian.org/DebianInstaller/Preseed).
 
 
 ### config/preseed/


### PR DESCRIPTION
    - https://debian-live-config.readthedocs.io/en/latest/custom.html#config-includes-installer
    - https://wiki.debian.org moved the Preseed file
    - existing link in docs:
    - https://wiki.debian.org/Preseed
    - updated link in pr:
    - https://wiki.debian.org/DebianInstaller/Preseed